### PR TITLE
Fix clickSeq release button not registering

### DIFF
--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -6,7 +6,6 @@
 #include <math.h>
 #include "commands.h"
 #include "util.h"
-#include "time.h"
 
 //Controller:
 bool bControllerIsInitialised = false;
@@ -524,4 +523,16 @@ void sendUsbResponse(USBResponse response)
     usbCommsWrite((void*)&response, 4);
     if (response.size > 0)
         usbCommsWrite(response.data, response.size);
+}
+
+long getUnixTime()
+{
+	time_t unixTime = 0;
+    Result tg = timeGetCurrentTime(TimeType_UserSystemClock, (u64*)&unixTime);
+    if (R_FAILED(tg))
+	{
+		fatalThrow(tg);
+		return -1;
+	}
+	return unixTime;
 }

--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -451,7 +451,7 @@ void clickSequence(char* seq, u8* token)
         {
             // release
             currKey = parseStringToButton(&command[1]);
-            press(currKey);
+            release(currKey);
         }   
         else if (!strncmp(command, &startWait, 1))
         {

--- a/sys-botbase/source/commands.h
+++ b/sys-botbase/source/commands.h
@@ -71,4 +71,5 @@ void key(HiddbgKeyboardAutoPilotState* states, u64 sequentialCount);
 void clickSequence(char* seq, u8* token);
 void dateSkip();
 void resetTime();
+long getUnixTime();
 void sendUsbResponse(USBResponse response);

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -944,6 +944,18 @@ int argmain(int argc, char **argv)
 
     if(!strcmp(argv[0], "resetTime"))
         resetTime();
+	
+	if (!strcmp(argv[0], "getUnixTime"))
+	{
+		long time = getUnixTime();	
+		if (usb)
+		{
+			response.size = sizeof(long);
+			response.data = &time;
+			sendUsbResponse(response);
+		}
+        else printf("%016lX\n", time);
+	}
 
     return 0;
 }


### PR DESCRIPTION
Previously the ``-<button>`` command in a clickSeq would start holding the button instead of releasing it, functioning identically to ``+<button>``. This PR just changes that one line to call ``release`` instead of ``press``.

This PR is a duplicate of https://github.com/olliz0r/sys-botbase/pull/76 as the issue is present in both, so I'm unsure if you want to handle it differently.